### PR TITLE
ipam: be able to precise metric value when adding routes

### DIFF
--- a/pkg/ipam/ipam_linux.go
+++ b/pkg/ipam/ipam_linux.go
@@ -117,6 +117,7 @@ func ConfigureIface(ifName string, res *current.Result) error {
 			Dst:       &r.Dst,
 			LinkIndex: link.Attrs().Index,
 			Gw:        gw,
+			Priority:  r.Metric,
 		}
 
 		if err = netlink.RouteAddEcmp(&route); err != nil {

--- a/vendor/github.com/containernetworking/cni/pkg/types/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/types.go
@@ -135,8 +135,9 @@ func (d *DNS) Copy() *DNS {
 }
 
 type Route struct {
-	Dst net.IPNet
-	GW  net.IP
+	Dst    net.IPNet
+	GW     net.IP
+	Metric int
 }
 
 func (r *Route) String() string {
@@ -149,8 +150,9 @@ func (r *Route) Copy() *Route {
 	}
 
 	return &Route{
-		Dst: r.Dst,
-		GW:  r.GW,
+		Dst:    r.Dst,
+		GW:     r.GW,
+		Metric: r.Metric,
 	}
 }
 
@@ -200,8 +202,9 @@ func (e *Error) Print() error {
 
 // JSON (un)marshallable types
 type route struct {
-	Dst IPNet  `json:"dst"`
-	GW  net.IP `json:"gw,omitempty"`
+	Dst    IPNet  `json:"dst"`
+	GW     net.IP `json:"gw,omitempty"`
+	Metric int    `json:"metric,omitempty"`
 }
 
 func (r *Route) UnmarshalJSON(data []byte) error {
@@ -212,13 +215,15 @@ func (r *Route) UnmarshalJSON(data []byte) error {
 
 	r.Dst = net.IPNet(rt.Dst)
 	r.GW = rt.GW
+	r.Metric = rt.Metric
 	return nil
 }
 
 func (r Route) MarshalJSON() ([]byte, error) {
 	rt := route{
-		Dst: IPNet(r.Dst),
-		GW:  r.GW,
+		Dst:    IPNet(r.Dst),
+		GW:     r.GW,
+		Metric: r.Metric,
 	}
 
 	return json.Marshal(rt)


### PR DESCRIPTION
This PR allows to precise the metric associated with routes declared in the IPAM section of the CNI configuration.
For instance:
```
{
  "cniVersion": "1.0.0",
  "name": "prod",
  "type": "ptp",
  "ipMasq": false,
  "mtu": 1500,
  "ipam": {
    "type": "host-local",
    "ranges": [
      [{"subnet": "10.9.2.0/24"}],
      [{"subnet": "2001:db8:cafe::0/66"}]
    ],
    "routes": [
      {
        "dst": "0.0.0.0/0",
        "metric": 100
      }
    ]
  }
}
```
It has the advantage of being able to precise the same route in multiple network configuration for the sake of simplicity, while being able to prefer a route over another.

```
sudo ip -n testing route
default via 10.9.3.1 dev eth1 src 10.9.2.11 metric 10 
default via 10.9.2.1 dev eth0 metric 100 
```

The route with the lowest metric is preferred.