### PR TITLE
feat: add a retry mechanism to retrieve source interface IP

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,12 +65,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install test binaries
-        env:
-          GO111MODULE: off
         run: |
-          go get github.com/containernetworking/cni/cnitool
-          go get github.com/mattn/goveralls
-          go get github.com/modocache/gover
+          go install github.com/containernetworking/cni/cnitool@latest
+          go install github.com/mattn/goveralls@latest
+          go install github.com/modocache/gover@latest
 
       - name: test
         run: PATH=$PATH:$(go env GOPATH)/bin COVERALLS=1 ./test_linux.sh


### PR DESCRIPTION
When using the `route_source_interface_ipv4` option on the PTP plugin, and if the interface specified in this option is created by another CNI plugin called simultaneously with the first plugin, there's a good chance that the PTP plugin will return an error because the interface is not yet ready (with a configured IP). To guard against this eventuality, we've implemented a retry mechanism around the code responsible for obtaining the interface's IP address; in the event of an error, it will retry until the maximum retry threshold is reached.

Changes:
* added a retry mechanism (10 retries max) with a sleep interval of 1s to the function that retrieves the interface and its IP address